### PR TITLE
Fix header title text color setting for code blocks

### DIFF
--- a/src/css/codeblocks.css
+++ b/src/css/codeblocks.css
@@ -222,7 +222,7 @@ pre.code-styler-pre .code-styler-header-external-reference > button {
 	padding-top: calc(1em * var(--header-inner-vertical-padding));
 	padding-bottom: calc(1em * var(--header-inner-vertical-padding));
 	padding-left: 0px;
-	color: var(--code-styler-header-text-colour);
+	color: var(--code-styler-header-title-text-colour);
 	font-size: inherit;
 	font-style: var(--code-styler-header-title-text-italic, normal);
 	font-weight: var(--code-styler-header-title-text-bold, normal);


### PR DESCRIPTION
Fixed header title color in the code block.

## Description
The header title color configured in the code block settings was not applied.

## Motivation and Context


## How has this been tested?
I tested it by using the modified CSS in my Obsidian copy.

## Screenshots
-

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have checked no similar existing [pull requests](/../../../pulls) exist
- [x] I have checked the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
