### PR TITLE
fix the Line break of inline code when used in sheet

### DIFF
--- a/src/ReadingView.ts
+++ b/src/ReadingView.ts
@@ -148,7 +148,7 @@ async function remakeInlineCode(inlineCodeElement: HTMLElement, plugin: CodeStyl
 	const {parameters,text} = parseInlineCode(inlineCodeText);
 	if (parameters) {
 		inlineCodeElement.innerHTML = await getHighlightedHTML(parameters,text,plugin);
-		inlineCodeElement.innerHTML = inlineCodeElement.innerHTML + "&ZeroWidthSpace;";
+		inlineCodeElement.innerHTML = inlineCodeElement.innerHTML;
 		inlineCodeElement.classList.add("code-styler-inline");
 		const parameterString = inlineCodeText.substring(0,inlineCodeText.lastIndexOf(text));
 		inlineCodeElement.setAttribute("parameters",parameterString); // Store parameter string as attribute so original text can be restored on plugin removal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
deal the "&ZeroWidthSpace;" in readingciew.ts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
it will make a line break when i used a inline code in the table
