### PR TITLE
gh-docs/mkdocs-material highlight rule support

### DIFF
--- a/main.js
+++ b/main.js
@@ -19146,9 +19146,9 @@ function manageWrapping(parameterString, codeblockParameters) {
   }
 }
 function addHighlights(parameterString, codeblockParameters, theme) {
-  const highlightMatch = /^(\w+)[:=](.+)$/.exec(parameterString);
+  const highlightMatch = /^(\w+)[:=]"?([^"]+)"?$/.exec(parameterString);
   if (highlightMatch) {
-    if (highlightMatch[1] === "hl")
+    if (highlightMatch[1].startsWith("hl"))
       codeblockParameters.highlights.default = parseHighlightedLines(highlightMatch[2]);
     else if (highlightMatch[1] in theme.colours.light.highlights.alternativeHighlights)
       codeblockParameters.highlights.alternative[highlightMatch[1]] = parseHighlightedLines(highlightMatch[2]);
@@ -19156,7 +19156,7 @@ function addHighlights(parameterString, codeblockParameters, theme) {
     codeblockParameters.highlights.default = parseHighlightedLines(parameterString.slice(1, -1));
 }
 function parseHighlightedLines(highlightedLinesString) {
-  const highlightRules = highlightedLinesString.split(",");
+  const highlightRules = highlightedLinesString.split(/[\s,]+/); // Split by space or comma
   const lineNumbers = /* @__PURE__ */ new Set();
   const plainText = /* @__PURE__ */ new Set();
   const regularExpressions = /* @__PURE__ */ new Set();

--- a/src/Parsing/CodeblockParsing.ts
+++ b/src/Parsing/CodeblockParsing.ts
@@ -355,9 +355,9 @@ function manageWrapping(parameterString: string, codeblockParameters: CodeblockP
 	}
 }
 function addHighlights(parameterString: string, codeblockParameters: CodeblockParameters, theme: CodeStylerTheme) {
-	const highlightMatch = /^(\w+)[:=](.+)$/.exec(parameterString);
+	const highlightMatch = /^(\w+)[:=]"?([^"]+)"?$/.exec(parameterString);
 	if (highlightMatch) {
-		if (highlightMatch[1] === "hl")
+		if (highlightMatch[1].startsWith("hl"))
 			codeblockParameters.highlights.default = parseHighlightedLines(highlightMatch[2]);
 		else if (highlightMatch[1] in theme.colours.light.highlights.alternativeHighlights)
 			codeblockParameters.highlights.alternative[highlightMatch[1]] = parseHighlightedLines(highlightMatch[2]);
@@ -365,7 +365,7 @@ function addHighlights(parameterString: string, codeblockParameters: CodeblockPa
 		codeblockParameters.highlights.default = parseHighlightedLines(parameterString.slice(1,-1));
 }
 function parseHighlightedLines(highlightedLinesString: string): Highlights {
-	const highlightRules = highlightedLinesString.split(",");
+	const highlightRules = highlightedLinesString.split(/[\s,]+/); // Split by space or comma
 	const lineNumbers: Set<number> = new Set();
 	const plainText: Set<string> = new Set();
 	const regularExpressions: Set<RegExp> = new Set();


### PR DESCRIPTION
## Description
Updates the highlighting to retain existing functionality and add gh-docs highlight rule consistent with https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#highlighting-specific-lines

## Motivation and Context
Adds support for gh-docs with simple regex improvement.

## How has this been tested?
Tested with obsidian mkdocs-material.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have checked no similar existing [pull requests](/../../../pulls) exist
- [x] I have checked the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
